### PR TITLE
Change Git Clone -> Git Clone Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Clone
+# Git Clone Action
 
 ![Repository License](https://img.shields.io/github/license/sudosubin-ppas/git-clone-action)
 ![Repository Release](https://img.shields.io/github/v/release/sudosubin-ppas/git-clone-action)
@@ -45,4 +45,4 @@ This project is aiming to replace [`actions/checkout`](https://github.com/action
 
 ## License
 
-Git Clone is [MIT Licensed](./LICENSE).
+Git Clone Action is [MIT Licensed](./LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Git Clone'
+name: 'Git Clone Action'
 author: 'sudosubin'
 description: 'A action for cloning git repositories.'
 


### PR DESCRIPTION
- `Git Clone` is also non-unique name.
- Related: https://github.com/sudosubin-ppas/git-clone-action/pull/5

```
Name must be unique. Cannot match an existing action, user or organization name.
```